### PR TITLE
[Doc] Add runtime information to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,3 +256,8 @@ optional arguments:
 
 ```
 
+## Runtime
+
+Cmai is designed for large-scale inference on the binding properties between antigens and antibodies. Speed is thus an important factor in its scalability. Tested a GPU with BCR-antigen pairs sampled from SabDab,  we found the embedding step to take an average time of *11.84 minutes* for one antigen, whereas the binding step for one pair takes only *32.67 seconds*.
+
+In practice, the most common scenario is to test the binding between many BCRs against a specific antigen of interest, and in this case, the embedding step needs to be run **only once**, enabling efficient inferencce on massive datasets. 


### PR DESCRIPTION
This PR adds a nice little description on Cmai's speed, showcasing our efficiency. This is done so that users can have this nice feeling knowing that they were able to perform their binding predictions in a reasonably quick time.

This PR changes only the README file: there is no actual change to the code base. It should be easy to integrate into production.